### PR TITLE
Make bills show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'pundit'
 # gem 'bcrypt', '~> 3.1.7'
 gem 'money-rails'
 gem 'stripe'
+gem 'stripe_event'
+gem 'rqrcode', '~> 1.1', '>= 1.1.2'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chunky_png (1.3.11)
     cloudinary (1.12.0)
       aws_cf_signer
       rest-client
@@ -201,6 +202,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rqrcode (1.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 0.1)
+    rqrcode_core (0.1.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -230,6 +235,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stripe (5.22.0)
+    stripe_event (2.3.1)
+      activesupport (>= 3.1)
+      stripe (>= 2.8, < 6)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -286,12 +294,14 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.3, >= 6.0.3.2)
   redis (~> 4.0)
+  rqrcode (~> 1.1, >= 1.1.2)
   sass-rails (>= 6)
   selenium-webdriver
   simple_form
   spring
   spring-watcher-listen (~> 2.0.0)
   stripe
+  stripe_event
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/app/assets/stylesheets/components/_checkout.scss
+++ b/app/assets/stylesheets/components/_checkout.scss
@@ -1,0 +1,27 @@
+.peyment-form {
+  box-sizing: border-box;
+
+  height: 40px;
+
+  padding: 10px 12px;
+
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: white;
+
+  box-shadow: 0 1px 3px 0 #e6ebf1;
+  -webkit-transition: box-shadow 150ms ease;
+  transition: box-shadow 150ms ease;
+}
+
+.peyment-form--focus {
+  box-shadow: 0 1px 3px 0 #cfd7df;
+}
+
+.peyment-form--invalid {
+  border-color: #fa755a;
+}
+
+.peyment-form--webkit-autofill {
+  background-color: #fefde5 !important;
+}

--- a/app/assets/stylesheets/components/_checkout.scss
+++ b/app/assets/stylesheets/components/_checkout.scss
@@ -1,4 +1,4 @@
-.peyment-form {
+.StripeElement {
   box-sizing: border-box;
 
   height: 40px;
@@ -14,14 +14,14 @@
   transition: box-shadow 150ms ease;
 }
 
-.peyment-form--focus {
+.StripeElement--focus {
   box-shadow: 0 1px 3px 0 #cfd7df;
 }
 
-.peyment-form--invalid {
+.StripeElement--invalid {
   border-color: #fa755a;
 }
 
-.peyment-form--webkit-autofill {
+.StripeElement--webkit-autofill {
   background-color: #fefde5 !important;
 }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -2,3 +2,4 @@
 @import "alert";
 @import "avatar";
 @import "navbar";
+@import "checkout";

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,17 +1,21 @@
 class BillsController < ApplicationController
   before_action :set_bill, only: [:show, :edit, :update]
-  before_action :set_vendor, only: [:show, :edit]
+  before_action :set_vendor, only: [:new, :create, :show, :edit]
   skip_before_action :authenticate_user!, only: [:new, :create] # for vendor
 
   def new
     @bill = Bill.new
+    @bill.date = Time.now
+    authorize @bill
   end
 
   def create
-    @bill = Bill.new(booking_params)
-    @bill.vendor = params[:vendor_id]
+    @bill = Bill.new(bill_params)
+    @bill.vendor = @vendor
+    @bill.user = current_user
     @bill.price = params[:price]
     @bill.status = "pending"
+    authorize @bill
 
     if @bill.save
       redirect_to bill_path(@bill)

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,17 +1,27 @@
 class BillsController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :create ]
+  before_action :set_bill, only: [:show, :edit, :update]
+  before_action :set_vendor, only: [:show, :edit]
+  skip_before_action :authenticate_user!, only: [:new, :create] # for vendor
 
   def new
     @bill = Bill.new
-    authorize @bill
   end
 
   def create
+    @bill = Bill.new(booking_params)
+    @bill.vendor = params[:vendor_id]
+    @bill.price = params[:price]
+    @bill.status = "pending"
 
+    if @bill.save
+      redirect_to bill_path(@bill)
+    else
+      render :new
+    end
   end
 
   def show
-
+    authorize @bill
   end
 
   def edit
@@ -20,6 +30,20 @@ class BillsController < ApplicationController
 
   def update
 
+  end
+
+  private
+
+  def set_bill
+    @bill = Bill.find(params[:id])
+  end
+
+  def bill_params
+    params.require(:bill).permit(:date, :status, :price)
+  end
+
+  def set_vendor
+    @vendor = Vendor.find(params[:vendor_id])
   end
 
 end

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,6 +1,6 @@
 class BillsController < ApplicationController
   before_action :set_bill, only: [:show, :edit, :update]
-  before_action :set_vendor, only: [:new, :create, :show, :edit]
+  before_action :set_vendor, only: [:new, :create]
   skip_before_action :authenticate_user!, only: [:new, :create] # for vendor
 
   def new
@@ -12,8 +12,8 @@ class BillsController < ApplicationController
   def create
     @bill = Bill.new(bill_params)
     @bill.vendor = @vendor
-    @bill.user = current_user
-    @bill.price = params[:price]
+    @bill.user = User.find(params[:bill][:user_id])
+    @bill.price = params[:bill][:price]
     @bill.status = "pending"
     authorize @bill
 

--- a/app/inputs/currency_input.rb
+++ b/app/inputs/currency_input.rb
@@ -1,0 +1,22 @@
+class CurrencyInput < SimpleForm::Inputs::Base
+  def input(wrapper_options)
+    currency = options.delete(:currency) || default_currency
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    content_tag(:div, input_group(currency, merged_input_options), class: "input-group")
+  end
+
+  private
+
+  def input_group(currency, merged_input_options)
+    "#{currency_addon(currency)} #{@builder.text_field(attribute_name, merged_input_options)}".html_safe
+  end
+
+  def currency_addon(currency)
+    content_tag(:span, currency, class: "input-group-addon mr-3")
+  end
+
+  def default_currency
+    "€"
+  end
+end

--- a/app/inputs/currency_input.rb
+++ b/app/inputs/currency_input.rb
@@ -13,7 +13,7 @@ class CurrencyInput < SimpleForm::Inputs::Base
   end
 
   def currency_addon(currency)
-    content_tag(:span, currency, class: "input-group-addon mr-3")
+    content_tag(:span, currency, class: "input-group-text")
   end
 
   def default_currency

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,6 +24,7 @@ require("channels")
 
 // External imports
 import "bootstrap";
+import "@stripe/stripe-js";
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';

--- a/app/javascript/plugins/init_checkout.js
+++ b/app/javascript/plugins/init_checkout.js
@@ -1,11 +1,13 @@
+import {loadStripe} from '@stripe/stripe-js';
+
+const stripe = await loadStripe(STRIPE_PUBLISHABLE_KEY);
+
 // Create a Stripe client.
 var stripe = Stripe(STRIPE_PUBLISHABLE_KEY);
 
 // Create an instance of Elements.
 var elements = stripe.elements();
 
-// Custom styling can be passed to options when creating an Element.
-// (Note that this demo uses a wider set of styles than the guide below.)
 var style = {
   base: {
     color: '#32325d',

--- a/app/javascript/plugins/init_checkout.js
+++ b/app/javascript/plugins/init_checkout.js
@@ -1,13 +1,11 @@
-import {loadStripe} from '@stripe/stripe-js';
-
-const stripe = await loadStripe(STRIPE_PUBLISHABLE_KEY);
-
 // Create a Stripe client.
-var stripe = Stripe(STRIPE_PUBLISHABLE_KEY);
+var stripe = Stripe(STRIPE_SECRET_KEY);
 
 // Create an instance of Elements.
 var elements = stripe.elements();
 
+// Custom styling can be passed to options when creating an Element.
+// (Note that this demo uses a wider set of styles than the guide below.)
 var style = {
   base: {
     color: '#32325d',

--- a/app/javascript/plugins/init_checkout.js
+++ b/app/javascript/plugins/init_checkout.js
@@ -1,0 +1,70 @@
+// Create a Stripe client.
+var stripe = Stripe(STRIPE_PUBLISHABLE_KEY);
+
+// Create an instance of Elements.
+var elements = stripe.elements();
+
+// Custom styling can be passed to options when creating an Element.
+// (Note that this demo uses a wider set of styles than the guide below.)
+var style = {
+  base: {
+    color: '#32325d',
+    fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+    fontSmoothing: 'antialiased',
+    fontSize: '16px',
+    '::placeholder': {
+      color: '#aab7c4'
+    }
+  },
+  invalid: {
+    color: '#fa755a',
+    iconColor: '#fa755a'
+  }
+};
+
+// Create an instance of the card Element.
+var card = elements.create('card', {style: style});
+
+// Add an instance of the card Element into the `card-element` <div>.
+card.mount('#card-element');
+
+// Handle real-time validation errors from the card Element.
+card.on('change', function(event) {
+  var displayError = document.getElementById('card-errors');
+  if (event.error) {
+    displayError.textContent = event.error.message;
+  } else {
+    displayError.textContent = '';
+  }
+});
+
+// Handle form submission.
+var form = document.getElementById('payment-form');
+form.addEventListener('submit', function(event) {
+  event.preventDefault();
+
+  stripe.createToken(card).then(function(result) {
+    if (result.error) {
+      // Inform the user if there was an error.
+      var errorElement = document.getElementById('card-errors');
+      errorElement.textContent = result.error.message;
+    } else {
+      // Send the token to your server.
+      stripeTokenHandler(result.token);
+    }
+  });
+});
+
+// Submit the form with the token ID.
+function stripeTokenHandler(token) {
+  // Insert the token ID into the form so it gets submitted to the server
+  var form = document.getElementById('payment-form');
+  var hiddenInput = document.createElement('input');
+  hiddenInput.setAttribute('type', 'hidden');
+  hiddenInput.setAttribute('name', 'stripeToken');
+  hiddenInput.setAttribute('value', token.id);
+  form.appendChild(hiddenInput);
+
+  // Submit the form
+  form.submit();
+}

--- a/app/policies/bill_policy.rb
+++ b/app/policies/bill_policy.rb
@@ -5,16 +5,17 @@ class BillPolicy < ApplicationPolicy
     end
   end
 
-  def new?
-    show?
+  def create?
+    true
   end
 
   def show?
     true
   end
 
-  def create?
-    true
+  def update?
+    record.user == user
   end
+
 
 end

--- a/app/views/bills/new.html.erb
+++ b/app/views/bills/new.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-12">
+
+    Date : <%= @bill.date.strftime("%d %b %Y") %>
+    <%= simple_form_for [@vendor, @bill] do |f| %>
+    <%= f.hidden_field :date %>
+    <%= f.association :vendor %>
+    <%= f.association :user %>
+    <%= f.input :price %>
+    <%= f.submit class: "btn btn-primary" %>
+  <% end %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <div class="row">
+
+  <p>Amount: <%= humanized_money_with_symbol(@bill.price) %></p>
+
+  </div>
+</div>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -7,5 +7,27 @@
     <p>Amount: <%= humanized_money_with_symbol(@bill.price) %></p>
 
     </div>
+
+    <div class="col-12">
+      <script src="https://js.stripe.com/v3/"></script>
+
+        <form action="/charge" method="post" id="payment-form">
+          <div class="form-row">
+            <label for="card-element">
+              Credit or debit card
+            </label>
+            <div id="card-element">
+              <!-- A Stripe Element will be inserted here. -->
+            </div>
+
+            <!-- Used to display form errors. -->
+            <div id="card-errors" role="alert"></div>
+          </div>
+
+          <button>Pay</button>
+        </form>
+      <script src="https://js.stripe.com/v3/"></script>
+    </div>
+
   </div>
 </div>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -26,7 +26,6 @@
 
           <button>Pay</button>
         </form>
-      <script src="https://js.stripe.com/v3/"></script>
     </div>
 
   </div>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -1,7 +1,11 @@
 <div class="container">
-  <div class="row">
+  <div class="row justify-content-center">
+    <div class="col-12">
 
-  <p>Amount: <%= humanized_money_with_symbol(@bill.price) %></p>
+    <p>You are goint to send money to </p>
+    <h5><%= @bill.vendor.name %></h5>
+    <p>Amount: <%= humanized_money_with_symbol(@bill.price) %></p>
 
+    </div>
   </div>
 </div>

--- a/app/views/bills/show.html.erb
+++ b/app/views/bills/show.html.erb
@@ -1,31 +1,44 @@
-<div class="container">
+<div class="container-sm p-5">
   <div class="row justify-content-center">
     <div class="col-12 text-center">
 
-    <p>You are goint to send money to </p>
-    <h5><%= @bill.vendor.name %></h5>
-    <h5 class="alert alert-primary" role="alert"><span class="currency_symbol">$</span><span class="btn btn-primary"><%= humanized_money @money_object %></span></h5>
+      <p>You are goint to send money to </p>
+      <h5><%= @bill.vendor.name %></h5>
+      <div class="input-group input-group-lg mb-3">
+        <div class="input-group-prepend">
+            <span class="currency_symbol input-group-text" id="inputGroup-sizing-lg"><%= currency_symbol %></span>
+           </div>
+        <input type="text" class="form-control text-right" placeholder="<%= humanized_money @bill.price %>" aria-describedby="inputGroup-sizing-lg">
+      </div>
 
+        <div class="card rounded mb-3 justify-content-sm-around">
+          <div class="card-body">
+            <button type="button" class="btn btn-secondary p-2 bd-highlight rounded">5%</button>
+            <button type="button" class="btn btn-dark p-2 bd-highlight rounded">10%</button>
+            <button type="button" class="btn btn-secondary p-2 bd-highlight rounded">15%</button>
+            <button type="button" class="btn btn-secondary p-2 bd-highlight rounded">€</button>
+            <span class="ml-auto p-2 bd-highlight text-secondary">Tips</span>
+          </div>
+        </div>
+
+        <div class="card rounded mb-3 justify-content-sm-around">
+          <div class="card-body">
+            <i class="fab fa-cc-visa bd-highlight" style="font-size:32px"></i>
+            <span class="ml-auto p-2 bd-highlight text-secondary">Change</span>
+          </div>
+        </div>
     </div>
 
-    <div class="col-12 text-center">
-      <script src="https://js.stripe.com/v3/"></script>
 
-        <form action="/charge" method="post" id="payment-form">
-          <div class="form-row">
-            <label for="card-element">
-              Credit or debit card
-            </label>
-            <div id="card-element">
-              <!-- A Stripe Element will be inserted here. -->
-            </div>
-
-            <!-- Used to display form errors. -->
-            <div id="card-errors" role="alert"></div>
-          </div>
-
-          <button>Pay</button>
-        </form>
+    <div class="col-12 text-center fixed-bottom mb-5">
+      <script
+        src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+        data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
+        data-amount="<%= @bill.price_cents %>"
+        data-name="Your payment for"
+        data-description="<%= @bill.vendor.name %>"
+        data-currency="<%= @bill.price.currency %>">
+      </script>
     </div>
 
   </div>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "@stripe/stripe-js": "^1.8.0",
     "bootstrap": "^4.5.0",
     "jquery": "^3.5.1",
     "mapbox-gl": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/webpacker": "4.2.2",
     "@stripe/stripe-js": "^1.8.0",
     "bootstrap": "^4.5.0",
+    "install": "^0.13.0",
     "jquery": "^3.5.1",
     "mapbox-gl": "^1.11.1",
     "popper.js": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3865,6 +3865,11 @@ ini@^1.3.4, ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
+install@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/install/-/install-0.13.0.tgz#6af6e9da9dd0987de2ab420f78e60d9c17260776"
+  integrity sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,6 +966,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@stripe/stripe-js@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.8.0.tgz#100f102d757cd024f94635dba231993554c8cfba"
+  integrity sha512-VsIohJw70LIdB4b621RN6pTyw49ZMy+QjB81fl+Psu5X5ppiq/c+rG0F+XKHSVpp4JZRNDkQnsOGeuHow0aluA==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"


### PR DESCRIPTION
I made two pages ; 
1. bills#new for vendor
2. bills#show for user.
 
bills#new is not a part of a user journey, but I made it for development purpose.

I'm struggling to implement the Stripe Elements in bills#show page. 
Now a different window pops up for payment. 
But when I succeed in implementing the Stripe Element, payment will be done in the same page. 

Please do not pay much attention to the design. 

Excuse me for not dividing these changes into two branches. 

bills#new (for vendor)
![image](https://user-images.githubusercontent.com/61164812/88602353-f0061100-d072-11ea-8c19-fe05e4d9e3e1.png)

bills#show (for user)
![image](https://user-images.githubusercontent.com/61164812/88602380-04e2a480-d073-11ea-88b6-fb975e7bd568.png)

payment (stripe)
![image](https://user-images.githubusercontent.com/61164812/88604011-c7801600-d076-11ea-938c-f1389bef29cd.png)
