### PR TITLE
Migration File deleted because it was caousing migration problems

### DIFF
--- a/db/migrate/20200730214452_rename_column_dc_cc_to_card_type.rb
+++ b/db/migrate/20200730214452_rename_column_dc_cc_to_card_type.rb
@@ -1,5 +1,0 @@
-class RenameColumnDcCcToCardType < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :cards, :dc_cc, :card_type
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_214452) do
+ActiveRecord::Schema.define(version: 2020_07_30_184655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There was a conflict with one migrations file.
Few days ago I change the 'type' column from Cards table to 'dc_cc' (debit card - credit card). 
Yesterday Matt did the same but from 'type' to another name. Boths migrations were on the same folder and causing issues while migrating. 
Firts a migration from **type** to **dc_cc** and then next migrations was searching for **type** but it didn't exist enymore.
