### PR TITLE
Bypass to bills#show

### DIFF
--- a/app/views/shared/_plus_menu.html.erb
+++ b/app/views/shared/_plus_menu.html.erb
@@ -3,7 +3,7 @@
 </div>
 <div class="plus-menu-big">
   <div class="fa-camera">
-    <%= link_to '<i class="fas fa-camera"></i>'.html_safe, '#' %>
+    <%= link_to '<i class="fas fa-camera"></i>'.html_safe, bill_path(Bill.first) %>
   </div>
   <div class="fa-exchange-alt">
     <%= link_to '<i class="fas fa-exchange-alt"></i>'.html_safe, '#' %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -423,11 +423,11 @@ comments = [
   "The waiter was sleeping",
   "No comments",
   "Best brunch ever",
-  "The mimosas were excelent",
+  "The mimosas were excellent",
   "I love it",
   "Best place to use the app",
   "I had a hair on my soup",
-  "The booking was cancell without notice",
+  "The booking was cancelled without notice",
   "We wait 30 mins under the rain",
   "We had to use mask while eating...",
   "Never again",
@@ -448,4 +448,15 @@ comments = [
 end
 
 puts "Reviews done"
+
+puts "Creating a bill"
+  bill_first = Bill.create(
+    date: "2020-08-01",
+    status: "pending",
+    user_id: User.first.id,
+    vendor_id: Vendor.first.id,
+    price_cents: 2789,
+    )
+puts "Bill #{bill_first.id} was created"
+
 puts "Seeds Done"


### PR DESCRIPTION
Solely during the development phase. 
Until the QR code reader is made, I made a bypass to the `bills#show `page. 
Please do `rails db:seed`, to create a bill. 

When you click the camera btn, it takes you to the bills#show page.

This link will removed when the QR code reader works.

![image](https://user-images.githubusercontent.com/61164812/89099574-9e51e380-d3f0-11ea-8a6b-fa87e68c8977.png)


![image](https://user-images.githubusercontent.com/61164812/89099576-a0b43d80-d3f0-11ea-81e1-0bdb8420cca0.png)
