### PR TITLE
btn geolocation moved to top

### DIFF
--- a/app/assets/stylesheets/pages/_map.scss
+++ b/app/assets/stylesheets/pages/_map.scss
@@ -75,7 +75,7 @@ input#query::placeholder {
   box-shadow: none;
 }
 .mapboxgl-ctrl-top-right {
-  top: 90%;
+  top: 10%;
   right: 0;
 }
 


### PR DESCRIPTION
The geolocation BTN has been moved to the top

![Screen Shot 2020-08-18 at 09 14 52](https://user-images.githubusercontent.com/56911839/90482317-54c50080-e133-11ea-9e7c-8c2282fc8b6a.png)
![Screen Shot 2020-08-18 at 09 15 39](https://user-images.githubusercontent.com/56911839/90482351-65757680-e133-11ea-8bd4-1ed9096c650e.png)
