### PR TITLE
Reviews#new placeholder font-size adjusted, border box no transparent…

### DIFF
--- a/app/assets/stylesheets/components/_ratings.scss
+++ b/app/assets/stylesheets/components/_ratings.scss
@@ -55,19 +55,18 @@ textarea#review_content{
   color: #939393;
 }
 
-.review-set-content{
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  // display: grid;
-  // grid-template-columns: 1fr 1fr;
-  // grid-gap: 15px;
+.collection_radio_buttons{
+  width: 100%;
 }
 
 
+.placeholder-reviews .review_content textarea::placeholder{
+  font-size: 14px;
+}
 
-
-
+textarea.form-control:focus {
+  border-color: rgba(0,0,0,0.5);
+}
 
 
 

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -14,7 +14,7 @@
           <div>
             <%= f.input :set_content, as: :radio_buttons, wrapper_html: { class: "radio-buttons review-set-content" }, collection: Review::SET_CONTENT, label: "" %>
           </div>
-          <div>
+          <div class="placeholder-reviews">
             <%= f.input :content, label: false, :placeholder => 'Or write something...' %>
           </div>
           <div class="send-btn-center">


### PR DESCRIPTION
- I adjust the font-size of the placeholder in Reviews#New.
- When you click on the box, the border isn't transparent anymore.
- The radio-btns from the page now they are centered and width 100%.

![Screen Shot 2020-08-18 at 10 10 53](https://user-images.githubusercontent.com/56911839/90487833-4aa70000-e13b-11ea-8e5d-8c0455c869a9.png)
