### PR TITLE
Reviews page content darker

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   def default_url_options
     { host: ENV["DOMAIN"] || "localhost:3000" }
   end
+
   private
 
   def skip_pundit?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   include Pundit
+  include MetaTagsHelper
 
   # Pundit: white-list approach.
   after_action :verify_authorized, except: :index, unless: :skip_pundit?


### PR DESCRIPTION
Somehow the **MetaTagsHelper** where giving me an error on my local environment, but not on Production (heroku).
![Screen Shot 2020-08-19 at 11 07 31](https://user-images.githubusercontent.com/56911839/90616901-4f88b400-e20e-11ea-97b3-1e8fdd332f9b.png)
I just added `include MetaTagsHelper` on the applications_controller.rb and now it works locally.
![Screen Shot 2020-08-19 at 11 24 25](https://user-images.githubusercontent.com/56911839/90617089-8f4f9b80-e20e-11ea-81aa-879d29d6e051.png)

